### PR TITLE
Protected strings in environment variable values in Execute resources result in a traceback.

### DIFF
--- a/yaybu/core/shell.py
+++ b/yaybu/core/shell.py
@@ -198,7 +198,11 @@ class ShellCommand(change.Change):
                     env[var] = os.environ[var]
 
         if self.env:
-            env.update(self.env)
+            for key, item in self.env.iteritems():
+                if isinstance(item, String):
+                    env[key] = item.unprotected.encode("UTF-8")
+                else:
+                    env[key] = item
 
         self._generated_env = env
 

--- a/yaybu/providers/tests/test_execute.py
+++ b/yaybu/providers/tests/test_execute.py
@@ -94,6 +94,20 @@ class TestExecute(FakeChrootTestCase):
             """)
         self.failUnlessExists("/etc/foo")
 
+    def test_environment_protected(self):
+        self.fixture.check_apply("""
+            secreted_string.secret: /etc/foo_secret
+
+            resources:
+                - Execute:
+                    name: test
+                    command: sh -c "touch $FOO"
+                    environment:
+                        FOO: ${secreted_string}
+                    creates: /etc/foo_secret
+            """)
+        self.failUnlessExists("/etc/foo_secret")
+
     def test_returncode(self):
         """ test that the returncode is interpreted as expected. """
         self.fixture.check_apply("""


### PR DESCRIPTION
If an environment variable value is a yay protected string, yaybu exits with a traceback. Included are two commits - one to test for the issue, one with a proposed solution to the bug.

```
/-------------------------------- Execute[test] --------------------------------
| # sh -c touch $FOO
| Exception: TypeError('putenv() argument 2 must be string, not String',)
| Exception: putenv() argument 2 must be string, not String
Traceback (most recent call last):
  File "/usr/local/bin/yaybu", line 9, in <module>
    load_entry_point('Yaybu==0.1.22dev', 'console_scripts', 'yaybu')()
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/main.py", line 88, in main
    rv = r.run(ctx)
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/runner.py", line 80, in run
    changed = ctx.get_bundle().apply(ctx, ctx.get_config())
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/resource.py", line 336, in apply
    if resource.apply(ctx, config):
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/resource.py", line 180, in apply
    changed = prov.apply(context)
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/providers/execute.py", line 87, in apply
    self.execute(context.shell, command, self.resource.returncode)
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/providers/execute.py", line 43, in execute
    umask=self.resource.umask
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/shell.py", line 296, in execute
    self.context.changelog.apply(cmd)
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/change.py", line 227, in apply
    return change.apply(text_class(self, self.verbose))
  File "/usr/local/lib/python2.6/dist-packages/Yaybu-0.1.22dev-py2.6.egg/yaybu/core/shell.py", line 243, in apply
    preexec_fn=self.preexec,
  File "/usr/lib/python2.6/subprocess.py", line 633, in __init__
    errread, errwrite)
  File "/usr/lib/python2.6/subprocess.py", line 1139, in _execute_child
    raise child_exception
TypeError: putenv() argument 2 must be string, not String
```
