### PR TITLE
Static content that comes from an encrypted source should not be visible

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Changelog for yaybu
 0.1.22 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Mark "static" file content retrieved over a gpg stream as secret to prevent
+  the content appearing in the logs.
 
 
 0.1.21 (2012-03-16)

--- a/yaybu/providers/filesystem/files.py
+++ b/yaybu/providers/filesystem/files.py
@@ -288,8 +288,9 @@ class File(provider.Provider):
             contents = template.render(self.get_template_args()) + "\n" # yuk
             sensitive = self.has_protected_strings()
         elif self.resource.static:
-            contents = context.get_file(self.resource.static).read()
-            sensitive = False
+            fp = context.get_file(self.resource.static)
+            contents = fp.read()
+            sensitive = getattr(fp, 'secret', False)
         elif self.resource.encrypted:
             contents = context.get_decrypted_file(self.resource.encrypted).read()
             sensitive = True


### PR DESCRIPTION
This branch checks for streams marked as "secret" and prevents their display in any diff output.
