### PR TITLE
Better error handling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,11 @@ Changelog for yaybu
 0.1.25 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix default verbosity to not be debug mode
+
+- Use context log features of latest yay version to provide better error
+  messages when yay parsing fails. These are only shown when verbosity is at
+  debug level.
 
 
 0.1.24 (2012-07-30)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='Yaybu',
       install_requires=[
           'setuptools',
           'jinja2',
-          'yay >= 0.0.53',
+          'yay >= 0.0.57',
           'python-dateutil < 2.0',
       ],
       extras_require = {

--- a/yaybu/core/main.py
+++ b/yaybu/core/main.py
@@ -15,6 +15,7 @@
 import os
 import optparse
 import yay
+import yay.errors
 from yaybu.core import runner, remote, runcontext
 import logging, atexit
 
@@ -34,7 +35,7 @@ def main():
     parser.add_option("", "--log-level", default="info", help="the minimum log level to write to the audit trail")
     parser.add_option("-d", "--debug", default=False, action="store_true", help="switch all logging to maximum, and write out to the console")
     parser.add_option("-l", "--logfile", default=None, help="The filename to write the audit log to, instead of syslog. Note: the standard console log will still be written to the console.")
-    parser.add_option("-v", "--verbose", default=2, action="count", help="Write additional informational messages to the console log. repeat for even more verbosity.")
+    parser.add_option("-v", "--verbose", default=0, action="count", help="Write additional informational messages to the console log. repeat for even more verbosity.")
     parser.add_option("--host", default=None, action="store", help="A host to remotely run yaybu on")
     parser.add_option("-u", "--user", default="root", action="store", help="User to attempt to run as")
     parser.add_option("--remote", default=False, action="store_true", help="Run yaybu.protocol client on stdio")
@@ -55,7 +56,14 @@ def main():
 
     if opts.expand_only:
         ctx = runcontext.RunContext(args[0], opts)
-        cfg = ctx.get_config().get()
+
+        try:
+            cfg = ctx.get_config().get()
+        except yay.errors.LanguageError as e:
+            print str(e)
+            if opts.verbose >= 2:
+                print yay.errors.get_exception_context()
+            return 1
 
         if opts.verbose <= 2:
             cfg = dict(resources=cfg.get("resources", []))

--- a/yaybu/core/runcontext.py
+++ b/yaybu/core/runcontext.py
@@ -20,7 +20,7 @@ import StringIO
 
 import yay
 from yay.openers import Openers
-from yay.errors import NotFound, NotModified
+from yay.errors import LanguageError, NotFound, NotModified, get_exception_context
 
 from yaybu.core import change, resource, vfs
 from yaybu.core.error import ParseError, MissingAsset, Incompatible, UnmodifiedAsset
@@ -156,6 +156,9 @@ class RunContext(object):
             return c
 
         except yay.errors.Error, e:
+            msg = e.get_string()
+            if self.verbose >= 2:
+                msg += "\n" + get_exception_context()
             raise ParseError(e.get_string())
 
     def set_bundle(self, bundle):
@@ -165,8 +168,8 @@ class RunContext(object):
         if self._bundle:
             return self._bundle
 
-        cfg = self.get_config().mapping
-        bundle = resource.ResourceBundle.create_from_yay_expression(cfg.get("resources").expand())
+        cfg = self.get_config().lookup("resources")
+        bundle = resource.ResourceBundle.create_from_yay_expression(cfg, verbose_errors=self.verbose>=2)
         bundle.bind()
         self._bundle = bundle
 


### PR DESCRIPTION
The newer versions of Yay can fetch context information from the traceback of any exceptions raised allowing better and more useful information to be presented to people using Yaybu. This branch exposes that information to anyone who invokes yaybu in debug mode.
