### PR TITLE
Disable cloud stuff in release versions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ Changelog for yaybu
 0.1.27 (unreleased)
 -------------------
 
+- Add new commands for dealing with collections of nodes on cloud providers:
+  ``addnode``, ``rmnode``, ``status`` and ``provision``. These are currently
+  only available if the ``IS_DEVELOPMENT`` environment variable is set.
+
 - Mark "static" file content retrieved over a gpg stream as secret to prevent
   the content appearing in the logs.
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,14 +4,17 @@ allow-hosts = *
 develop = .
 parts =
     test
-    yaybu
     docs
+    yaybu
 include-site-packages = false
 exec-sitecustomize = false
 versions = versions
 
 [yaybu]
 recipe = zc.recipe.egg
+initialization =
+    import os
+    os.environ['IS_DEVELOPMENT'] = 'YES'
 eggs = yaybu
 
 [docs]

--- a/yaybu/core/command.py
+++ b/yaybu/core/command.py
@@ -371,3 +371,11 @@ class YaybuCmd(OptionParsingCmd):
         """ Exit yaybu """
         print
         self.do_quit()
+
+
+if os.environ.get("IS_DEVELOPMENT", "") != "YES":
+    del YaybuCmd.do_provision
+    del YaybuCmd.do_status
+    del YaybuCmd.do_addnode
+    del YaybuCmd.do_rmnode
+


### PR DESCRIPTION
Here is a really simple and noddy pattern for landing experimental features in master that degrade in release versions. In this case i'm disabling the cloud stuff for anyone not using a buildout of Yaybu allowing us to release with the same feature set as 0.1.x.
