### PR TITLE
Harness refactoring

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,16 +2,12 @@
 # vi: set ft=ruby :
 
 Vagrant::Config.run do |config|
-  config.vm.box = "lucid64"
-
-  config.vm.customize ["modifyvm", :id, "--memory", "1024"]
-
-  config.vm.define :yaybu do |web_config|
-    web_config.vm.network :hostonly, "10.33.32.2"
-    
-    web_config.vm.forward_port 22, 3333     # real ssh
-
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  
+  config.vm.define :yaybu do |cfg|
+    cfg.vm.network :hostonly, "10.33.32.2"
+    cfg.vm.forward_port 22, 3333     # real ssh
   end
-
 end
 

--- a/yaybu/harness/fakechroot.py
+++ b/yaybu/harness/fakechroot.py
@@ -210,7 +210,7 @@ class FakeChrootFixture(Fixture):
                 LD_LIBRARY_PATH.append(path)
         LD_LIBRARY_PATH.extend(glob.glob("/usr/lib/*/fakechroot"))
 
-        for path in ("/usr/lib/fakeroot", ):
+        for path in ("/usr/lib/libfakeroot", ):
             if os.path.exists(path):
                 LD_LIBRARY_PATH.append(path)
         LD_LIBRARY_PATH.extend(glob.glob("/usr/lib/*/libfakeroot"))

--- a/yaybu/harness/fakechroot.py
+++ b/yaybu/harness/fakechroot.py
@@ -106,8 +106,8 @@ class FakeChrootFixture(Fixture):
 
         subprocess.check_call(["cp", "-al", self.testbase, self.chroot_path])
 
-	# This is the same delightful incantation used in cow-shell to setup an
-	# .ilist file for our fakechroot.
+        # This is the same delightful incantation used in cow-shell to setup an
+        # .ilist file for our fakechroot.
         subprocess.check_call([
             "cowdancer-ilistcreate",
             self.ilist_path,

--- a/yaybu/harness/fakechroot.py
+++ b/yaybu/harness/fakechroot.py
@@ -36,18 +36,6 @@ auditlog:
    mode: file
 """
 
-# A little SSH wrapper for faking SSH into a fakechroot
-# (Obviously won't let us fake paramiko...)
-sshwrapper = """
-#! /usr/bin/env python
-import os, sys
-args = sys.argv[1:]
-while args and not args[0] == "yaybu":
-    del args[0]
-if args:
-    os.execvp(args[0], args)
-""".strip()
-
 distro_flags = {
     "Ubuntu 9.10": dict(
         name="karmic",

--- a/yaybu/harness/fakechroot.py
+++ b/yaybu/harness/fakechroot.py
@@ -153,7 +153,8 @@ class FakeChrootFixture(Fixture):
 
     def refresh_environment(self):
         commands = [
-             "rm -rf /usr/local/lib/python2.6/dist-packages/Yaybu*",
+             "fakeroot fakechroot rm -rf /usr/local/lib/python2.6/dist-packages/Yaybu*",
+             "fakeroot fakechroot rm -rf /usr/local/lib/python2.7/dist-packages/Yaybu*",
              "python setup.py sdist --dist-dir %(base_image)s",
              "fakeroot fakechroot /usr/sbin/chroot %(base_image)s sh -c 'easy_install /Yaybu-*.tar.gz'",
              ]


### PR DESCRIPTION
This fixes the `LD_PRELOAD` style harness for lucid and precise.

It is tested on lucid and precise. The network tests successfully run.

Both `fakeroot` and `fakechroot` are just shell scripts that munge `LD_` environment variables. While `cow-shell` is written in C it's doing little more than setting some environment variables and calling `cowdancer-ilistcreate`.

Applying this fixes the error messages about invalid arguments in fakeroot.

This improves the quality of the environment by preserving the inode list (ilist) between invocations during the same test. Previously cow-shell would have run `find .` on the entire chroot before every command.

With this change the ilist file is managed by the fixture. By avoiding cow-shell we stop the spawning of a cleanup process for each yaybu invocation that has previously been the source of races (and are thus able to remove the workaround for the race - a nasty `while cond / sleep` beastie.

Applying this patch removes 3 processes from the test for each call() invocation. Each yaybu invocation tends to to call yaybu 3 times(to test simulate, to test apply, then to make sure no more changes are made). This means that it saves 9 processes per test. I'm guessing running the test suite starts 900 processes less at least. 300 of these processes would have been `bash` interpreters. Another 300 would have `sh` interpreters.
