### PR TITLE
Refactor handling of yaybu arguments and yay config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Changelog for yaybu
 0.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add a subclass of ``yay.config.Config`` that helps adapt yay for use in
+  Yaybu..
 
 
 0.2.3 (2012-10-25)

--- a/yaybu/core/config.py
+++ b/yaybu/core/config.py
@@ -1,0 +1,77 @@
+# Copyright 2012 Isotoma Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from yay.errors import Error, get_exception_context
+from yay.config import Config as BaseConfig
+
+from yaybu.error import ParseError
+
+
+class Config(BaseConfig):
+
+    """
+    This class adapts ``yay.config.Config`` for use in Yaybu. In particular it
+    helps to ensure that Yaybu API users only have to deal with Yaybu
+    exceptions and not yay exceptions. It also applies so default Yaybu
+    policies like looking in ``~/.yaybu/`` for certain things.
+    """
+
+    def __init__(self, context, host=None):
+        self.context = context
+
+        config = {
+            "openers": {
+                "packages": {
+                    "cachedir": os.path.expanduser("~/.yaybu/packages"),
+                    },
+                },
+            }
+
+        super(Config, self).__init__(context.ypath, config)
+
+        if hostname:
+            self.set_hostname(hostname)
+
+        defaults = os.path.expanduser("~/.yaybu/defaults.yay")
+        if os.path.exists(defaults):
+            self.load_uri(defaults)
+
+        defaults_gpg = os.path.expanduser("~/.yaybu/defaults.yay.gpg")
+        if os.path.exists(defaults_gpg):
+            self.load_uri(defaults_gpg)
+
+    def set_hostname(self, hostname):
+        self.add({
+            "yaybu": {
+                "host": self.host,
+                }
+            })
+
+    def _reraise_yay_errors(self, func, *args, **kwargs):
+        try:
+            return func(*args, **kwargs):
+        except Error, e:
+            msg = e.get_string()
+            if self.context.verbose > 2:
+                msg += "\n" + get_exception_context()
+            raise ParseError(e.get_string())        
+
+    def load_uri(self, *args, **kwargs):
+        return self._reraise_yay_errors(super(Config, self).load_uri, *args, **kwargs)
+
+    def add(self, mapping):
+        return self._reraise_yay_errors(super(Config, self).add, mapping)
+

--- a/yaybu/core/config.py
+++ b/yaybu/core/config.py
@@ -17,7 +17,7 @@ import os
 from yay.errors import Error, NoMatching, get_exception_context
 from yay.config import Config as BaseConfig
 
-from yaybu.error import ParseError
+from yaybu.core.error import ParseError
 
 
 class YaybuArgParsingError(Exception):
@@ -99,7 +99,7 @@ class Config(BaseConfig):
     policies like looking in ``~/.yaybu/`` for certain things.
     """
 
-    def __init__(self, context, host=None):
+    def __init__(self, context, hostname=None):
         self.context = context
 
         config = {
@@ -110,7 +110,7 @@ class Config(BaseConfig):
                 },
             }
 
-        super(Config, self).__init__(context.ypath, config)
+        super(Config, self).__init__(searchpath=context.ypath, config=config)
 
         if hostname:
             self.set_hostname(hostname)
@@ -131,7 +131,7 @@ class Config(BaseConfig):
         except NoMatching:
             args = []
  
-       for arg in args:
+        for arg in args:
             if 'name' not in arg:
                 raise KeyError("No name specified for an argument")
             yarg = YaybuArg(arg['name'], 
@@ -141,11 +141,11 @@ class Config(BaseConfig):
                             )
             parser.add(yarg)
 
-       self.add({
-           "yaybu": {
-               "argv": parser.parse(arguments),
-               }
-           })
+        self.add({
+            "yaybu": {
+                "argv": parser.parse(**arguments),
+                }
+            })
 
     def set_arguments_from_argv(self, argv):
         arguments = {}
@@ -165,7 +165,7 @@ class Config(BaseConfig):
 
     def _reraise_yay_errors(self, func, *args, **kwargs):
         try:
-            return func(*args, **kwargs):
+            return func(*args, **kwargs)
         except Error, e:
             msg = e.get_string()
             if self.context.verbose > 2:

--- a/yaybu/core/config.py
+++ b/yaybu/core/config.py
@@ -17,11 +17,7 @@ import os
 from yay.errors import Error, NoMatching, get_exception_context
 from yay.config import Config as BaseConfig
 
-from yaybu.core.error import ParseError
-
-
-class YaybuArgParsingError(Exception):
-    pass
+from yaybu.core.error import ParseError, ArgParseError
 
 
 class YaybuArg:
@@ -52,7 +48,7 @@ class YaybuArg:
             try:
                 return int(value)
             except ValueError:
-                raise YaybuArgParsingError("Cannot convert %r to an int for argument %r" % (value, self.name))
+                raise ArgParseError("Cannot convert %r to an int for argument %r" % (value, self.name))
         elif self.type == 'boolean':
             if type(value) == type(True):
                 # might already be boolean
@@ -61,9 +57,9 @@ class YaybuArg:
                 return False
             elif value.lower() in ('yes', '1', 'on', 'true'):
                 return True
-            raise YaybuArgParsingError("Cannot parse boolean from %r for argument %r" % (value, self.name))
+            raise ArgParseError("Cannot parse boolean from %r for argument %r" % (value, self.name))
         else:
-            raise YaybuArgParsingError("Don't understand %r as a type for argument %r" % (self.type, self.name))
+            raise ArgParseError("Don't understand %r as a type for argument %r" % (self.type, self.name))
 
 
 class YaybuArgParser:
@@ -75,13 +71,13 @@ class YaybuArgParser:
 
     def add(self, arg):
         if arg.name in self.args:
-            raise YaybuArgParsingError("Duplicate argument %r specified" % (arg.name,))
+            raise ArgParseError("Duplicate argument %r specified" % (arg.name,))
         self.args[arg.name] = arg
 
     def parse(self, **arguments):
         for name, value in arguments.items():
             if name not in self.args:
-                raise YaybuArgParsingError("Unexpected argument %r provided" % (name,))
+                raise ArgParseError("Unexpected argument %r provided" % (name,))
             self.args[name].set(value)
         return dict(self.values())
 
@@ -152,7 +148,7 @@ class Config(BaseConfig):
         for arg in argv:
             name, value = arg.split("=", 1)
             if name in arguments:
-                raise YaybuArgParsingError("Duplicate argument %r specified" % (name,))
+                raise ArgParseError("Duplicate argument %r specified" % (name,))
             arguments[name] = value
         self.set_arguments(**arguments)
 

--- a/yaybu/core/error.py
+++ b/yaybu/core/error.py
@@ -170,6 +170,10 @@ class UnmodifiedAsset(ExecutionError):
     handling and should be filed as a bug against Yaybu. """
     returncode = 153
 
+class ArgParseError(ParseError):
+    """ Error parsing an argument that was applied to a config """
+    returncode = 154
+
 class NothingChanged(ExecutionError):
     """ Not really an error, but we need to know if this happens for our
     tests. This exception is never really raised, but it's useful to keep the

--- a/yaybu/core/runcontext.py
+++ b/yaybu/core/runcontext.py
@@ -134,6 +134,7 @@ class RunContext(object):
             return self._config
 
         self._config = Config(self)
+        self._config.load_uri(self.configfile)
         return self._config
 
     def set_bundle(self, bundle):

--- a/yaybu/core/tests/test_command.py
+++ b/yaybu/core/tests/test_command.py
@@ -2,6 +2,7 @@
 
 import unittest
 from yaybu.core import config
+from yaybu.core.error import ArgParseError
 
 
 class TestYaybuArg(unittest.TestCase):
@@ -31,7 +32,7 @@ class TestYaybuArg(unittest.TestCase):
     def test_integer_bad(self):
         arg = config.YaybuArg('foo', 'integer', default=20)
         arg.set("boo")
-        self.assertRaises(config.YaybuArgParsingError, arg.get)
+        self.assertRaises(ArgParseError, arg.get)
         
     def test_boolean(self):
         arg = config.YaybuArg('foo', 'boolean')
@@ -53,7 +54,7 @@ class TestYaybuArg(unittest.TestCase):
     def test_unknown(self):
         arg = config.YaybuArg('foo', 'meh', default=20)
         arg.set("boo")
-        self.assertRaises(config.YaybuArgParsingError, arg.get)
+        self.assertRaises(ArgParseError, arg.get)
         
         
         

--- a/yaybu/core/tests/test_command.py
+++ b/yaybu/core/tests/test_command.py
@@ -1,39 +1,40 @@
 # coding=utf-8
 
 import unittest
-from yaybu.core import command
+from yaybu.core import config
+
 
 class TestYaybuArg(unittest.TestCase):
     
     def test_string(self):
-        arg = command.YaybuArg('foo')
+        arg = config.YaybuArg('foo')
         arg.set("hello")
         self.assertEqual(arg.get(), "hello")
         
     def test_default(self):
-        arg = command.YaybuArg('foo', default="hello")
+        arg = config.YaybuArg('foo', default="hello")
         self.assertEqual(arg.get(), "hello")
         
     def test_integer(self):
-        arg = command.YaybuArg('foo', 'integer')
+        arg = config.YaybuArg('foo', 'integer')
         arg.set("10")
         self.assertEqual(arg.get(), 10)
         
     def test_boolean_default(self):
-        arg = command.YaybuArg('foo', 'boolean', default=False)
+        arg = config.YaybuArg('foo', 'boolean', default=False)
         self.assertEqual(arg.get(), False)
         
     def test_integer_default(self):
-        arg = command.YaybuArg('foo', 'integer', default=20)
+        arg = config.YaybuArg('foo', 'integer', default=20)
         self.assertEqual(arg.get(), 20)
         
     def test_integer_bad(self):
-        arg = command.YaybuArg('foo', 'integer', default=20)
+        arg = config.YaybuArg('foo', 'integer', default=20)
         arg.set("boo")
-        self.assertRaises(command.YaybuArgParsingError, arg.get)
+        self.assertRaises(config.YaybuArgParsingError, arg.get)
         
     def test_boolean(self):
-        arg = command.YaybuArg('foo', 'boolean')
+        arg = config.YaybuArg('foo', 'boolean')
         arg.set("1")
         self.assertEqual(arg.get(), True)
         arg.set("yes")
@@ -50,9 +51,9 @@ class TestYaybuArg(unittest.TestCase):
         self.assertEqual(arg.get(), False)
     
     def test_unknown(self):
-        arg = command.YaybuArg('foo', 'meh', default=20)
+        arg = config.YaybuArg('foo', 'meh', default=20)
         arg.set("boo")
-        self.assertRaises(command.YaybuArgParsingError, arg.get)
+        self.assertRaises(config.YaybuArgParsingError, arg.get)
         
         
         

--- a/yaybu/harness/fakechroot.py
+++ b/yaybu/harness/fakechroot.py
@@ -238,7 +238,6 @@ class FakeChrootFixture(Fixture):
         args = list(args)
         if self.test_network:
             args.insert(0, "test://")
-            args.insert(0, "--host")
             args.insert(0, "push")
         else:
             args.insert(0, "apply")


### PR DESCRIPTION
This is the one of the first units of refactoring.

It:
- creates a new subclass of `yay.config.Config` which has all the logic for loading defaults.
- moves a lot of config setup code to `yaybu/core/config.py`
- picks up the searchpath from a context object
- wraps `Config.load_uri` and `Config.add` so that they raise Yaybu errors
- Adds both `Config.set_arguments` and `Config.set_arguments_from_argv`
- moves the YaybuArg code to `yaybu/core/config.py`
- makes YaybuArgParsingError a proper Yaybu exception (this should mean the cmdline prints nice stderr messages on problems, alas commands.py doesn't do this uniformly yet)

And in order to test this change, I tidied up `yaybu apply` and `yaybu push` a little (fixing things like validation) and added command line arguments to them.
