### PR TITLE
Remove logic from commands

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -43,3 +43,119 @@ because it will be capitalised.
    resources/service
    resources/prompt
 
+Command line arguments
+======================
+
+You can specify that additional arguments can be provided to yaybu, which are
+made available to your configuration.
+
+You should specify the following in your configuration::
+
+    yaybu:
+        options:
+            - name: <name>
+              type: <type name from list of types below>
+              help: <help text shown to the user>
+              default: <default value>
+              
+
+For example:
+
+    yaybu:
+        options:
+            - name: version
+              type: string
+              help: The version of software to deploy
+              default: trunk
+
+You can then pass these arguments to yaybu as name=value pairs on the command line::
+
+    yaybu provision ... version=tag/1.0
+    
+The values provided by the user will be made available in the key yaybu.argv,
+for the example above this would look like::
+
+    yaybu:
+        argv:
+            version: tag/1.0
+       
+Argument types
+--------------
+
+ string
+   The argument will be provided as a string
+ integer
+   The argument will be converted into an integer
+ boolean
+   The argument will be converted into a boolean. All common english ways of specifying booleans are supported (0, 1, yes, no, on, off etc.)
+   
+   
+Deploying to the cloud
+======================
+
+When Yaybu is used to deploy to cloud infrastructures such as AWS, Yaybu
+populates a set of configuration terms with the configuration of these hosts,
+so that your configuration can refer to it.
+
+We recommend that you build all of your configurations against such an API,
+so that if you ever do wish to deploy existing configurations to the cloud
+you can do so.
+
+Defining your cloud
+-------------------
+
+You need to specify the names of the clouds and sufficient details about them
+so that appropriate instances can be started::
+
+    clouds:
+        <name>:
+            default: <true if this is to be the default cloud>
+            providers:
+                compute: <name of libcloud compute provider>
+                storage <name of libcloud storage provider>
+                dns: <name of libcloud dns provider>
+            args:
+                <arguments to provide to the providers>
+            images:
+                <your name>: <their name>
+            sizes:
+                <your name>: <their name>
+            keys:
+                <key name>: <url of key file>
+
+Roles
+-----
+
+Initially you will need to define the roles you wish to deploy. This is used
+by Yaybu to determine how many hosts, and of what type, to start at your
+chosen cloud service.
+
+Your roles should look like::
+
+    roles:
+    
+        <name>:
+            key: <name of ssh key to use>
+            instance:
+                image: <image name to use>
+                size: <size name to use>
+            include:
+                - <path to yay file to include when deploying to this role>
+            max: <maximum number of this role allowed to run>
+            min: <minimum number of this role allowed to run>
+            dns:
+                zone: <zone that the server will exist in>
+                name: <host name within the zone>
+
+Provided configuration
+----------------------
+
+Yaybu will create a set of terms that looks like this::
+
+    yaybu:
+        provider:
+        cluster:
+        argv:
+        
+    hosts:
+        

--- a/yaybu/core/cloud/api.py
+++ b/yaybu/core/cloud/api.py
@@ -10,6 +10,7 @@ from libcloud.dns.providers import get_driver as get_dns_driver
 from libcloud.compute.deployment import MultiStepDeployment, ScriptDeployment, SSHKeyDeployment
 import libcloud.security
 from libcloud.common.types import LibcloudError
+from libcloud.storage.types import ContainerDoesNotExistError
 
 from boto.route53.exception import DNSServerError
 from boto.route53.connection import Route53Connection
@@ -81,25 +82,29 @@ class Cloud(object):
 
     """ Adapter of a cloud that provides access to runtime functionality. """
 
-    def __init__(self, compute_provider, storage_provider, dns_provider, args):
+    def __init__(self, compute_provider, storage_provider, dns_provider, args=(), compute_args=(), storage_args=()):
+        """ storage_args and compute_args will be used for preference if
+        provided. otherwise args are used for both """
         self.compute_provider = compute_provider
         self.storage_provider = storage_provider
         self.dns_provider = dns_provider
-        self.args = args
+        self.args = dict(args)
+        self.compute_args = dict(compute_args) or self.args
+        self.storage_args = dict(storage_args) or self.args
 
     @property
     @memoized
     def compute(self):
         provider = getattr(ComputeProvider, self.compute_provider)
         driver_class = get_compute_driver(provider)
-        return driver_class(**self.args)
+        return driver_class(**self.compute_args)
     
     @property
     @memoized
     def storage(self):
         provider = getattr(StorageProvider, self.storage_provider)
         driver_class = get_storage_driver(provider)
-        return driver_class(**self.args)
+        return driver_class(**self.storage_args)
     
     @property
     @memoized
@@ -154,12 +159,8 @@ class Cloud(object):
                 logger.warning("Node did not start before timeout. retrying.")
                 node.destroy()
                 continue
-            if not name in self.nodes:
-                logger.debug("Naming fail for new node. retrying.")
-                node.destroy()
-                continue
             logger.debug("Node %r running" % (name, ))
-            return self.nodes[name]
+            return node
         logger.error("Unable to create node successfully. giving up.")
         raise IOError()
 

--- a/yaybu/core/cloud/cluster.py
+++ b/yaybu/core/cloud/cluster.py
@@ -427,6 +427,9 @@ class Cluster:
             get_encrypted(p['args']),
             get_encrypted(p['images']),
             get_encrypted(p['sizes']),
+            args=get_encrypted(p.get('args', {})), 
+            compute_args=get_encrypted(p.get('compute_args', {})),
+            storage_args=get_encrypted(p.get('storage_args', {})),
             )
         cluster = Cluster(cloud, cluster_name, roles)
         return cluster

--- a/yaybu/core/cloud/cluster.py
+++ b/yaybu/core/cloud/cluster.py
@@ -157,7 +157,7 @@ class AbstractCloud:
     your own internal names for images and sizes, to increase portability.
     """
     
-    def __init__(self, compute_provider, storage_provider, dns_provider, args, images, sizes):
+    def __init__(self, compute_provider, storage_provider, dns_provider, images, sizes, args=(), compute_args=(), storage_args=()):
         """
         Args:
             compute_provider: The name of the compute provider in libcloud
@@ -167,9 +167,10 @@ class AbstractCloud:
             images: A dictionary of images that maps your names to the providers names
             sizes: A dictionary of sizes that maps your names to the providers names
         """
-        self.cloud = api.Cloud(compute_provider, storage_provider, dns_provider, args)
-        self.images = images
-        self.sizes = sizes
+        self.cloud = api.Cloud(compute_provider, storage_provider, dns_provider, args, compute_args, storage_args)
+        # DUMMY provider has numeric images and sizes
+        self.images = dict([(x,str(y)) for (x,y) in images.items()])
+        self.sizes = dict([(x,str(y)) for (x,y) in sizes.items()])
         
     @property
     def nodes(self):

--- a/yaybu/core/cloud/cluster.py
+++ b/yaybu/core/cloud/cluster.py
@@ -376,3 +376,122 @@ class Cluster:
         key = self.roles[role].key
         self.install_yaybu(node, key)
         return node
+
+    def get_key(self, ctx, provider, key_name):
+        """ Load the key specified by name. """
+        clouds = ctx.get_config().mapping.get('clouds').resolve()
+        filename = get_encrypted(clouds[provider]['keys'][key_name])
+        saved_exception = None
+        for pkey_class in (RSAKey, DSSKey):
+            try:
+                file = ctx.get_file(filename)
+                key = pkey_class.from_private_key(file)
+                return key
+            except SSHException, e:
+                saved_exception = e
+        raise saved_exception
+
+    def extract_roles(self, ctx, provider):
+        roles = ctx.get_config().mapping.get('roles').resolve()
+        for k, v in roles.items():
+            dns = None
+            if 'dns' in v:
+                zone = get_encrypted(v['dns']['zone'])
+                name = get_encrypted(v['dns']['name'])
+                dns = SimpleDNSNamingPolicy(zone, name)
+            yield Role(
+                k,
+                get_encrypted(v['key']),
+                self.get_key(ctx, provider, get_encrypted(v['key'])),
+                get_encrypted(v['instance']['image']),
+                get_encrypted(v['instance']['size']),
+                get_encrypted(v.get('depends', ())),
+                dns,
+                get_encrypted(v.get('min', 0)),
+                get_encrypted(v.get('max', None)))
+
+    def get_cluster(self, ctx, provider, cluster_name, filename):
+        """ Create a ScalableCloud object from the configuration provided.
+        """
+
+        clouds = ctx.get_config().mapping.get('clouds').resolve()
+        p = clouds.get(provider, None)
+        if p is None:
+            raise KeyError("provider %r not found" % provider)
+        roles = self.extract_roles(ctx, provider)
+        cloud = AbstractCloud(
+            get_encrypted(p['providers']['compute']),
+            get_encrypted(p['providers']['storage']),
+            get_encrypted(p['providers']['dns']),
+            get_encrypted(p['args']),
+            get_encrypted(p['images']),
+            get_encrypted(p['sizes']),
+            )
+        cluster = Cluster(cloud, cluster_name, roles)
+        return cluster
+
+    def delete_cloud(self, ctx, provider, cluster_name, filename):
+        clouds = ctx.get_config().mapping.get('clouds').resolve()
+        p = clouds.get(provider, None)
+        if p is None:
+            raise KeyError("provider %r not found" % provider)
+
+    def host_info(self, info, role_name, role):
+        """ Information for a host to be inserted into the configuration.
+        Pass an info structure from cloud.get_node_info """
+        ## TODO refactor into cloud or an adapter
+        hostname = info['fqdn']
+        host = copy.copy(info)
+        host['role'] = {}
+        host['rolename'] = role_name
+        for k, v in role.items():
+            host['role'][k] = copy.copy(v)
+        return host
+
+    def decorate_config(self, ctx, provider, cluster, cloud=None):
+        """ Update the configuration with the details for all running nodes """
+        new_cfg = {'hosts': [],
+                   'yaybu': {
+                       'provider': provider,
+                       'cluster': cluster,
+                       'argv': {},
+                       }
+                   }
+        if cloud is not None:
+            roles = ctx.get_config().mapping.get('roles').resolve()
+            for role_name, role in cloud.roles.items():
+                for node in role.nodes.values():
+                    node_info = cloud.get_node_info(node)
+                    struct = self.host_info(node_info, role_name, roles[role_name])
+                    new_cfg['hosts'].append(struct)
+        ctx.get_config().add(new_cfg)
+
+    def create_initial_context(self, provider, cluster_name, filename):
+        """ Creates a context suitable for instantiating a cloud """
+        ctx = runcontext.RunContext(filename, ypath=self.ypath, verbose=self.verbose)
+        self.decorate_config(ctx, provider, cluster_names)
+        return ctx
+    
+    def create_host_context(self, hostname, provider, cluster_name, filename, cloud):
+        """ Creates the context used to provision an actual host """
+        ctx = runcontext.RunContext(filename, ypath=self.ypath, verbose=self.verbose, resume=True)
+        self.decorate_config(ctx, provider, cluster_name, cloud)
+        ctx.set_host(hostname)
+        ctx.get_config().load_uri("package://yaybu.recipe/host.yay")
+        return ctx
+
+    def create_runner(self, ctx, provider, hostname):
+        """ Create a runner for the specified host, using the key found in
+        the configuration """
+        hosts = ctx.get_config().mapping.get("hosts").resolve()
+        host = filter(lambda h: h['fqdn'] == hostname, hosts)[0]
+        key_name = host['role']['key']
+        key = self.get_key(ctx, provider, key_name)
+        r = remote.RemoteRunner(hostname, key)
+        return r
+    
+    def dump(self, ctx, filename):
+        """ Dump the configuration in a raw form """
+        cfg = ctx.get_config().get()
+        open(filename, "w").write(yay.dump(cfg))
+

--- a/yaybu/core/cloud/cluster.py
+++ b/yaybu/core/cloud/cluster.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 
 import StringIO
 import datetime

--- a/yaybu/core/cloud/tests/dummy.py
+++ b/yaybu/core/cloud/tests/dummy.py
@@ -1,15 +1,18 @@
 
 from libcloud.compute.drivers.dummy import DummyNodeDriver
-from libcloud.storage.drivers.dummy import DummyStorageDriver
-from libcloud.dns.drivers.dummy import DummyDNSDriver
+from libcloud.storage.drivers.dummy import DummyStorageDriver as OrigDummyStorageDriver
+from libcloud.dns.drivers.dummy import DummyDNSDriver as OrigDummyDNSDriver
 
 
 class DummyComputeDriver(DummyNodeDriver):
     pass
 
-class DummyStorageDriver(DummyStorageDriver):
-    pass
+class DummyStorageDriver(OrigDummyStorageDriver):
+    
+    def upload_object_via_stream(self, iterator, container, object_name, extra=None):
+        """ I want to support a StringIO """
+        pass
 
-class DummyDNSDriver(DummyDNSDriver):
+class DummyDNSDriver(OrigDummyDNSDriver):
     pass
 

--- a/yaybu/core/cloud/tests/dummy.py
+++ b/yaybu/core/cloud/tests/dummy.py
@@ -1,0 +1,15 @@
+
+from libcloud.compute.drivers.dummy import DummyNodeDriver
+from libcloud.storage.drivers.dummy import DummyStorageDriver
+from libcloud.dns.drivers.dummy import DummyDNSDriver
+
+
+class DummyComputeDriver(DummyNodeDriver):
+    pass
+
+class DummyStorageDriver(DummyStorageDriver):
+    pass
+
+class DummyDNSDriver(DummyDNSDriver):
+    pass
+

--- a/yaybu/core/cloud/tests/test_cluster.py
+++ b/yaybu/core/cloud/tests/test_cluster.py
@@ -71,9 +71,9 @@ class TestAbstractCloud(unittest.TestCase):
             'EC2_EU_WEST',
             'S3_EU_WEST',
             'DNS',
-            {},
             {'ubuntu': 'frob'},
             {'medium': 'nicate'},
+            args={},
             )
         cloud.cloud = Mock()
         cloud.cloud.images ={'frob': Mock(id='frob')}

--- a/yaybu/core/cloud/tests/test_functional.py
+++ b/yaybu/core/cloud/tests/test_functional.py
@@ -1,93 +1,93 @@
 
-from yaybu.core.cloud import api
-from yaybu.core.command import YaybuCmd
-from libcloud.compute.providers import Provider as ComputeProvider
-from libcloud.storage.providers import Provider as StorageProvider
-from libcloud.dns.providers import Provider as DNSProvider
+#from yaybu.core.cloud import api
+#from yaybu.core.command import YaybuCmd
+#from libcloud.compute.providers import Provider as ComputeProvider
+#from libcloud.storage.providers import Provider as StorageProvider
+#from libcloud.dns.providers import Provider as DNSProvider
 
-from libcloud.compute import providers as compute_providers
-from libcloud.storage import providers as storage_providers
-from libcloud.dns import providers as dns_providers
+#from libcloud.compute import providers as compute_providers
+#from libcloud.storage import providers as storage_providers
+#from libcloud.dns import providers as dns_providers
 
-from mock import MagicMock as Mock
-import tempfile
-import unittest
+#from mock import MagicMock as Mock
+#import tempfile
+#import unittest
 
-class DummyComputeProvider(ComputeProvider):
-    YAYBUDUMMY = -1
+#class DummyComputeProvider(ComputeProvider):
+    #YAYBUDUMMY = -1
     
-class DummyStorageProvider(StorageProvider):
-    YAYBUDUMMY = -1
+#class DummyStorageProvider(StorageProvider):
+    #YAYBUDUMMY = -1
     
-class DummyDNSProvider(DNSProvider):
-    YAYBUDUMMY = -1
+#class DummyDNSProvider(DNSProvider):
+    #YAYBUDUMMY = -1
     
-api.ComputeProvider = DummyComputeProvider
-api.StorageProvider = DummyStorageProvider
-api.DNSProvider = DummyDNSProvider
+##api.ComputeProvider = DummyComputeProvider
+##api.StorageProvider = DummyStorageProvider
+##api.DNSProvider = DummyDNSProvider
 
-compute_providers.DRIVERS[DummyComputeProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyComputeDriver')
-storage_providers.DRIVERS[DummyStorageProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyStorageDriver')
-dns_providers.DRIVERS[DummyDNSProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyDNSDriver')
+##compute_providers.DRIVERS[DummyComputeProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyComputeDriver')
+##storage_providers.DRIVERS[DummyStorageProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyStorageDriver')
+##dns_providers.DRIVERS[DummyDNSProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyDNSDriver')
 
 
-test_commands = """
-clouds:
-    fake_cloud:
-        providers: 
-            compute: YAYBUDUMMY
-            storage: YAYBUDUMMY
-            dns: YAYBUDUMMY
-        compute_args:
-            creds: 5
-        storage_args:
-            api_key: x
-            api_secret: x
-        images:
-            FAKE_IMAGE_NAME: 1
-        sizes:
-            small: 1
-            medium: 2
-            big: 3
-        keys:
-            FAKE_KEY: package://yaybu/core/cloud/tests/test_keys.pem
+#test_commands = """
+#clouds:
+    #fake_cloud:
+        #providers: 
+            #compute: YAYBUDUMMY
+            #storage: YAYBUDUMMY
+            #dns: YAYBUDUMMY
+        #compute_args:
+            #creds: 5
+        #storage_args:
+            #api_key: x
+            #api_secret: x
+        #images:
+            #FAKE_IMAGE_NAME: 1
+        #sizes:
+            #small: 1
+            #medium: 2
+            #big: 3
+        #keys:
+            #FAKE_KEY: package://yaybu/core/cloud/tests/test_keys.pem
             
-roles:
-    foo:
-        key: FAKE_KEY
-        instance:
-            image: FAKE_IMAGE_NAME
-            size: medium
-        include:
-            package://yaybu/core/cloud/tests/commands_foo.yay
-        max: 1
-        min: 1
-        dns:
-            zone: example.com
-            name: foo
-    bar:
-        key: FAKE_KEY
-        instance:
-            image: FAKE_IMAGE_NAME
-            size: medium
-        include:
-            package://yaybu/core/cloud/tests/commands_bar.yay
-        max: 1
-        min: 1
-        dns:
-            zone: example.com
-            name: foo
+#roles:
+    #foo:
+        #key: FAKE_KEY
+        #instance:
+            #image: FAKE_IMAGE_NAME
+            #size: medium
+        #include:
+            #package://yaybu/core/cloud/tests/commands_foo.yay
+        #max: 1
+        #min: 1
+        #dns:
+            #zone: example.com
+            #name: foo
+    #bar:
+        #key: FAKE_KEY
+        #instance:
+            #image: FAKE_IMAGE_NAME
+            #size: medium
+        #include:
+            #package://yaybu/core/cloud/tests/commands_bar.yay
+        #max: 1
+        #min: 1
+        #dns:
+            #zone: example.com
+            #name: foo
         
-"""
+#"""
 
-class TestFunctional(unittest.TestCase):
+##class TestFunctional(unittest.TestCase):
     
-    def test_provision(self):
+    ##def test_provision(self):
         
-        cmd = YaybuCmd()
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.write(test_commands)
-        tmp.close()
-        cmd.do_provision({}, ["fake_cloud", "fake_cluster", tmp.name])
+        ##cmd = YaybuCmd()
+        ##tmp = tempfile.NamedTemporaryFile(delete=False)
+        ##tmp.write(test_commands)
+        ##tmp.close()
+        ##cmd.do_provision({}, ["fake_cloud", "fake_cluster", tmp.name])
         
         

--- a/yaybu/core/cloud/tests/test_functional.py
+++ b/yaybu/core/cloud/tests/test_functional.py
@@ -1,0 +1,93 @@
+
+from yaybu.core.cloud import api
+from yaybu.core.command import YaybuCmd
+from libcloud.compute.providers import Provider as ComputeProvider
+from libcloud.storage.providers import Provider as StorageProvider
+from libcloud.dns.providers import Provider as DNSProvider
+
+from libcloud.compute import providers as compute_providers
+from libcloud.storage import providers as storage_providers
+from libcloud.dns import providers as dns_providers
+
+from mock import MagicMock as Mock
+import tempfile
+import unittest
+
+class DummyComputeProvider(ComputeProvider):
+    YAYBUDUMMY = -1
+    
+class DummyStorageProvider(StorageProvider):
+    YAYBUDUMMY = -1
+    
+class DummyDNSProvider(DNSProvider):
+    YAYBUDUMMY = -1
+    
+api.ComputeProvider = DummyComputeProvider
+api.StorageProvider = DummyStorageProvider
+api.DNSProvider = DummyDNSProvider
+
+compute_providers.DRIVERS[DummyComputeProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyComputeDriver')
+storage_providers.DRIVERS[DummyStorageProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyStorageDriver')
+dns_providers.DRIVERS[DummyDNSProvider.YAYBUDUMMY] = ('yaybu.core.cloud.tests.dummy', 'DummyDNSDriver')
+
+
+test_commands = """
+clouds:
+    fake_cloud:
+        providers: 
+            compute: YAYBUDUMMY
+            storage: YAYBUDUMMY
+            dns: YAYBUDUMMY
+        compute_args:
+            creds: 5
+        storage_args:
+            api_key: x
+            api_secret: x
+        images:
+            FAKE_IMAGE_NAME: 1
+        sizes:
+            small: 1
+            medium: 2
+            big: 3
+        keys:
+            FAKE_KEY: package://yaybu/core/cloud/tests/test_keys.pem
+            
+roles:
+    foo:
+        key: FAKE_KEY
+        instance:
+            image: FAKE_IMAGE_NAME
+            size: medium
+        include:
+            package://yaybu/core/cloud/tests/commands_foo.yay
+        max: 1
+        min: 1
+        dns:
+            zone: example.com
+            name: foo
+    bar:
+        key: FAKE_KEY
+        instance:
+            image: FAKE_IMAGE_NAME
+            size: medium
+        include:
+            package://yaybu/core/cloud/tests/commands_bar.yay
+        max: 1
+        min: 1
+        dns:
+            zone: example.com
+            name: foo
+        
+"""
+
+class TestFunctional(unittest.TestCase):
+    
+    def test_provision(self):
+        
+        cmd = YaybuCmd()
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.write(test_commands)
+        tmp.close()
+        cmd.do_provision({}, ["fake_cloud", "fake_cluster", tmp.name])
+        
+        

--- a/yaybu/core/command.py
+++ b/yaybu/core/command.py
@@ -318,8 +318,8 @@ class YaybuCmd(OptionParsingCmd):
             self.simple_help("provision")
             return
         provider, cluster_name, filename = args[:3]
-        cluster = Cluster.get_cluster(provider, cluster_name, filename, argv=args[3:])
-        return cluster.provision()
+        cluster = Cluster(provider, cluster_name, filename, argv=args[3:])
+        return cluster.provision(dump=opts.dump)
            
     def do_zoneupdate(self, opts, args):
         """ 
@@ -330,7 +330,7 @@ class YaybuCmd(OptionParsingCmd):
             self.simple_help("zoneupdate")
             return
         provider, cluster_name, filename = args
-        cluster = Cluster.get_cluster(provider, cluster_name, filename)
+        cluster = Cluster(provider, cluster_name, filename)
         for role, nodename in cluster.get_all_roles_and_nodenames():
             cluster.node_zone_update(role.name, nodename)
         
@@ -368,7 +368,7 @@ class YaybuCmd(OptionParsingCmd):
             self.do_help((),("rmcluster",))
             return
         provider, cluster_name, filename = args
-        cluster = Cluster.get_cluster(provider, cluster_name, filename)
+        cluster = Cluster(provider, cluster_name, filename)
         for role in cluster.roles_in_order():
             print "%s %s %s min %s max %s depends %s" % (
                 role.name, role.image, role.size, role.min, role.max, role.depends)
@@ -386,7 +386,7 @@ class YaybuCmd(OptionParsingCmd):
             return
         provider, cluster_name, filename = args
         logger.info("Deleting cluster")
-        cluster = Cluster.get_cluster(provider, cluster_name, filename)
+        cluster = Cluster(provider, cluster_name, filename)
         for role, name in cluster.get_all_roles_and_nodenames():
             logger.warning("Destroying %r on request" % (name,))
             cluster.destroy_node(role, name)

--- a/yaybu/core/command.py
+++ b/yaybu/core/command.py
@@ -405,9 +405,11 @@ class YaybuCmd(OptionParsingCmd):
             get_encrypted(p['providers']['compute']), 
             get_encrypted(p['providers']['storage']), 
             get_encrypted(p['providers']['dns']),
-            get_encrypted(p['args']), 
             get_encrypted(p['images']), 
             get_encrypted(p['sizes']), 
+            args=get_encrypted(p.get('args', {})), 
+            compute_args=get_encrypted(p.get('compute_args', {})),
+            storage_args=get_encrypted(p.get('storage_args', {})),
             )
         cluster = Cluster(cloud, cluster_name, roles)
         return cluster

--- a/yaybu/core/config.py
+++ b/yaybu/core/config.py
@@ -155,7 +155,7 @@ class Config(BaseConfig):
     def set_hostname(self, hostname):
         self.add({
             "yaybu": {
-                "host": self.host,
+                "host": hostname,
                 }
             })
 


### PR DESCRIPTION
This is a WIP branch to remove all cluster handling logic out of commands (making them a thin shim that maps console commands to internal API).

I don't expect this to run in it's current state, but it should be structurally close.
